### PR TITLE
Adjust benchmark to add dynasm backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ pflang implementations:
 
 * _pflua_: Pflang compiled directly to Lua by pflua.
 
-See https://github.com/Igalia/pflua for more on pflua's two execution
+* _pflua-native_: Pflang compiled to x86 asm by pflua.
+
+See https://github.com/Igalia/pflua for more on pflua's three execution
 engines, and for more resources on pflang and BPF.
 
 ## Experimental environment

--- a/bench.lua
+++ b/bench.lua
@@ -8,6 +8,7 @@ end
 local dot = dirname(arg[0])
 
 package.path = package.path .. ";" .. dot .. "/deps/pflua/src/?.lua"
+                            .. ";" .. dot .. "/deps/pflua/deps/dynasm/?.lua"
 
 local ffi = require("ffi")
 local pf = require("pf")
@@ -59,6 +60,9 @@ local compilers = {
    end,
    pflua = function (filter)
       return pf.compile_filter(filter)
+   end,
+   ["pflua-native"] = function (filter)
+      return pf.compile_filter(filter, {native=true})
    end
 }
 

--- a/bench.mk
+++ b/bench.mk
@@ -1,9 +1,10 @@
 GUILE=guile
 
 PATH:=$(top_srcdir)/deps/pflua/deps/luajit/usr/local/bin:$(PATH)
-ENGINES:=libpcap linux-bpf linux-ebpf bpf-lua pflua
+ENGINES:=libpcap linux-bpf linux-ebpf bpf-lua pflua pflua-native
 CSV:=$(addsuffix .csv, $(ENGINES))
 ITERATIONS?=20
+export LD_LIBRARY_PATH := $(top_srcdir)/deps/pflua/deps/dynasm:$(LD_LIBRARY_PATH)
 
 all: $(PNG)
 


### PR DESCRIPTION
This lets you run the benchmarks with the new dynasm backend for pflua. I haven't updated the included graph images/writeup, but can do that as well if it sounds like a good idea.

For the actual runs, I also used `numactl` and `taskset` in `bench.mk` but the parameters for those are rather machine specific. Should I still include that here?